### PR TITLE
feat: add galileo logging to chat rag app

### DIFF
--- a/example-apps/chatbot-rag-app/api/utils.py
+++ b/example-apps/chatbot-rag-app/api/utils.py
@@ -1,0 +1,9 @@
+from typing_extensions import List, TypedDict
+from langchain_core.documents import Document
+
+
+# Define state for application
+class State(TypedDict):
+    question: str
+    context: List[Document]
+    answer: str

--- a/example-apps/chatbot-rag-app/env.example
+++ b/example-apps/chatbot-rag-app/env.example
@@ -90,3 +90,8 @@ OTEL_BSP_SCHEDULE_DELAY=3000
 # Change to affect behavior of which resources are detected. Note: these
 # choices are specific to the language, in this case Python.
 OTEL_EXPERIMENTAL_RESOURCE_DETECTORS=process_runtime,os,otel,telemetry_distro
+
+# Galileo logging env variables
+GALILEO_CONSOLE_URL="https://console.galileo.ai/"
+GALILEO_API_KEY="..."
+GALILEO_PROJECT_NAME="elastic-chat-rag-app"

--- a/example-apps/chatbot-rag-app/requirements.in
+++ b/example-apps/chatbot-rag-app/requirements.in
@@ -18,3 +18,6 @@ langchain-mistralai
 elastic-opentelemetry
 # Additional LLM support not yet in EDOT
 langtrace-python-sdk
+
+# Logging dependencies
+galileo_observe

--- a/example-apps/chatbot-rag-app/requirements.txt
+++ b/example-apps/chatbot-rag-app/requirements.txt
@@ -242,7 +242,7 @@ multidict==6.1.0
     #   yarl
 mypy-extensions==1.0.0
     # via typing-inspect
-numpy==2.2.4
+numpy
     # via
     #   elasticsearch
     #   langchain-aws
@@ -530,3 +530,5 @@ opentelemetry-instrumentation-system-metrics==0.52b0
 opentelemetry-instrumentation-tortoiseorm==0.52b0
 opentelemetry-instrumentation-urllib3==0.52b0
 elastic-opentelemetry-instrumentation-openai==0.6.1
+
+galileo_observe


### PR DESCRIPTION
Setting up Galileo logging to the elastic RAG chatbot example!

To make the Galileo integration cleaner, I refactored the main chat logic using LangGraph. This breaks the process down into clear steps (retrieve, generate) where we can easily add monitoring.